### PR TITLE
Fix chatbot guide slug

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -153,7 +153,7 @@ export default async function DashboardPage() {
             <p className="font-bold text-md">Welcome to {siteConfig.name} 🎉</p>
             <p className="text-sm">You are probably new to this platform.</p>
             <p className="text-sm">We recommend starting with our <a className="underline" href="/dashboard/onboarding">onboarding</a> for a step-by-step guide on how to create your first chatbot.</p>
-            <p className="text-sm">If you prefer you can also start with our <a target="_blank" className="underline" href="/guides/how-to-build-smart-chatbot-for-your-webiste">tutorial</a>.</p>
+            <p className="text-sm">If you prefer you can also start with our <a target="_blank" className="underline" href="/guides/how-to-build-smart-chatbot-for-your-website">tutorial</a>.</p>
             <br />
             <a href="/dashboard/onboarding"><Button><p className="pr-2">Open Onboarding</p>  <Icons.help className="h-4 w-4" /> ‍</Button></a>
           </div>

--- a/config/docs.ts
+++ b/config/docs.ts
@@ -71,7 +71,7 @@ export const docsConfig: DocsConfig = {
                 },
                 {
                     title: "Build smart assistant chatbot for your website",
-                    href: "/guides/how-to-build-smart-chatbot-for-your-webiste",
+                    href: "/guides/how-to-build-smart-chatbot-for-your-website",
                 },
                 {
                     title: "How to use message exports correctly",

--- a/content/guides/how-to-build-smart-chatbot-for-your-website/index.mdx
+++ b/content/guides/how-to-build-smart-chatbot-for-your-website/index.mdx
@@ -49,7 +49,7 @@ This file contains the content from which your chatbot retrieves information, ev
 Now, let’s proceed to create your first chatbot.
 
 1. Open this in your browser https://www.openassistantgpt.io/dashboard/new/chatbot
-2. Fill in the necessary informations by adding the name, welcome message, OpenAI model, files etc.
+2. Fill in the necessary information by adding the name, welcome message, OpenAI model, files etc.
 
 <img
   src="/new_chatbot_form.png"


### PR DESCRIPTION
## Summary
- rename guide folder "how-to-build-smart-chatbot-for-your-website"
- update docs sidebar link
- update dashboard page link
- fix typo in the guide

## Testing
- `npm run build` *(fails: contentlayer not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ca4c0a9c8324a2f8a7bbecf87b5b