### PR TITLE
Fix duplicate UserSubscriptionPlan definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -63,10 +63,6 @@ export type SiteConfig = {
   }
 }
 
-export type UserSubscriptionPlan = SubscriptionPlan &
-  Pick<User, "stripeCustomerId" | "stripeSubscriptionId"> & {
-    stripeCurrentPeriodEnd: number
-  }
 
 export type ChatbotConfig = {
   id: number


### PR DESCRIPTION
## Summary
- remove earlier UserSubscriptionPlan type without `isPro`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ca4ddbec8324b4585f38548ff53b