### PR TITLE
Add vitest tests for stream parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "build": "contentlayer build && prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
-    "email": "email dev --port 3001"
+    "email": "email dev --port 3001",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.2",
@@ -99,6 +100,7 @@
     "postcss": "^8.4.12",
     "prisma": "^5.11.0",
     "tailwindcss": "^3.3.5",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.5.0"
   }
 }

--- a/tests/read-data-stream.test.ts
+++ b/tests/read-data-stream.test.ts
@@ -1,0 +1,40 @@
+import { readDataStream } from '../lib/read-data-stream';
+import { formatStreamPart } from '../lib/utils';
+import type { StreamPartType } from '../lib/stream-parts';
+import { describe, it, expect } from 'vitest';
+
+function createStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    pull(controller) {
+      if (chunks.length === 0) {
+        controller.close();
+      } else {
+        controller.enqueue(chunks.shift()!);
+      }
+    },
+  });
+}
+
+describe('readDataStream', () => {
+  it('parses stream chunks into parts', async () => {
+    const encoder = new TextEncoder();
+    const streamString =
+      formatStreamPart('text', 'hello') +
+      formatStreamPart('text', 'world');
+    const bytes = encoder.encode(streamString);
+    const chunk1 = bytes.slice(0, 5);
+    const chunk2 = bytes.slice(5, 15);
+    const chunk3 = bytes.slice(15);
+    const reader = createStream([chunk1, chunk2, chunk3]).getReader();
+
+    const parts: StreamPartType[] = [];
+    for await (const part of readDataStream(reader)) {
+      parts.push(part);
+    }
+
+    expect(parts).toEqual([
+      { type: 'text', value: 'hello' },
+      { type: 'text', value: 'world' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `vitest` as a dev dependency and expose a `test` script
- test `readDataStream` by feeding simulated stream chunks

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ca4e290c8324a2ea4a919a864485